### PR TITLE
Feature/dte 578/GitHub action ecr codeartifact build

### DIFF
--- a/.github/workflows/build-deploy-and-tag-ecr-image.yml
+++ b/.github/workflows/build-deploy-and-tag-ecr-image.yml
@@ -1,0 +1,21 @@
+# Gets next git version tag, builds and deploys Docker image to ECR; if
+# successful, tags git with new version.
+on:
+  push:
+    branches:
+      - 'main'
+  # Enable manual run; must be in main branch to be available
+  workflow_dispatch:
+jobs:
+  ecr-build:
+    uses: nationalarchives/tre-github-actions/.github/workflows/docker-build-and-ecr-deploy.yml@0.0.3
+    with:
+      docker_image_name: 'tre-slack-alerts'
+      build_dir: 'tre-slack-alerts'
+      ecr_registry_path: 'tre-v2'
+    secrets:
+      AWS_OPEN_ID_CONNECT_ROLE_ARN: ${{ secrets.AWS_OPEN_ID_CONNECT_ROLE_ARN }}
+      AWS_CODEARTIFACT_REPOSITORY_NAME: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_NAME }}
+      AWS_CODEARTIFACT_REPOSITORY_DOMAIN: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_DOMAIN }}
+      AWS_CODEARTIFACT_REPOSITORY_ACCOUNT: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_ACCOUNT }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # tre-fn-slack-alerts
+
+* [GitHub Actions](#github-actions)
+* [GitHub Action Secrets](#github-action-secrets)
+
+## GitHub Actions
+
+| Action | Description |
+| --- | --- |
+| [`.github/workflows/build-deploy-and-tag-ecr-image.yml`](.github/workflows/build-deploy-and-tag-ecr-image.yml) | Gets next git version tag<br>Builds and deploys Docker image to ECR<br>If successful, tags git with new version |
+
+## GitHub Action Secrets
+
+Secret for main AWS authentication (using OpenID Connect):
+
+| Name                         | Description                                          |
+| ---------------------------- | ---------------------------------------------------- |
+| AWS_OPEN_ID_CONNECT_ROLE_ARN | ARN of AWS role used to authenticate GitHub with AWS |
+
+Other secrets:
+
+| Name                                | Description                                                              |
+| ----------------------------------- | ------------------------------------------------------------------------ |
+| AWS_CODEARTIFACT_REPOSITORY_NAME    | Name of AWS CodeArtifact repository to log in to for additional packages |
+| AWS_CODEARTIFACT_REPOSITORY_DOMAIN  | Name of AWS CodeArtifact repository's domain                             |
+| AWS_CODEARTIFACT_REPOSITORY_ACCOUNT | The AWS account ID that owns the CodeArtifact                            |
+| AWS_REGION                          | The AWS region to use for CodeArtifact and ECR                           |

--- a/tre-slack-alerts/Dockerfile
+++ b/tre-slack-alerts/Dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/lambda/python:3.9
+ARG PIP_INDEX_URL
+
+# Copy function code
+COPY tre_slack_alerts.py ${LAMBDA_TASK_ROOT}
+
+# Install the function's dependencies using file requirements.txt
+COPY requirements.txt ./requirements.txt
+RUN  yum -y update \
+     && yum clean all \
+     && pip install \
+       --requirement requirements.txt \
+       --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "tre_slack_alerts.lambda_handler" ]

--- a/tre-slack-alerts/requirements.txt
+++ b/tre-slack-alerts/requirements.txt
@@ -1,0 +1,1 @@
+# Used by common GitHub Action build workflow

--- a/tre-slack-alerts/tre_slack_alerts.py
+++ b/tre-slack-alerts/tre_slack_alerts.py
@@ -1,0 +1,48 @@
+import urllib3
+import json
+import os
+
+http = urllib3.PoolManager()
+
+
+def lambda_handler(event, context):
+    """
+    status can be either warning / success / error
+    """
+    print(event)
+    url = os.environ["SLACK_WEBHOOK_URL"]
+    env = os.environ["ENV"]
+    message = json.loads(event["Records"][0]["Sns"]["Message"])
+    msg = {}
+
+    execution = message["Execution"]
+    state_machine = message["StateMachine"]
+    message_event = message["Event"]
+    final_message = f"*STATUS* :o: \n  *Environment* `{env}` \n*ExecutionName* `{execution}` \n*StateMachine* `{state_machine}` \n"
+
+    if "Status" in message:
+        status = message["Status"]
+        if str(status) == "success":
+            print("Success Message received")
+            icon = ":large_green_circle:"
+            final_message = f"*STATUS* {icon} \n*Environment:* `{env}`\n*Event:* `{message_event}`\n*ExecutionName:* `{execution}`\n*StateMachine:* `{state_machine}`"
+        elif str(status) == "warning":
+            print("Warning Message received")
+            icon = ":large_orange_circle:"
+            error_message = message.get("ErrorMessage", "")
+            final_message = f"*STATUS* {icon} \n*Environment:* `{env}`\n*Event:* `{message_event}`\n*ExecutionName:* `{execution}`\n*StateMachine:* `{state_machine}`\n*ErrorMessage:*\n```{error_message}```"
+        else:
+            print("Error Message received")
+            icon = ":red_circle:"
+            error_message = message.get("ErrorMessage", "")
+            final_message = f"*STATUS* {icon} \n*Environment:* `{env}`\n*Event:* `{message_event}`\n*ExecutionName:* `{execution}`\n*StateMachine:* `{state_machine}`\n*ErrorMessage:*\n```{error_message}```"
+    msg = {
+        "channel": os.environ["SLACK_CHANNEL"],
+        "username": os.environ["SLACK_USERNAME"],
+        "text": final_message,
+        "icon_emoji": icon,
+    }
+
+    encoded_msg = json.dumps(msg, indent=2).encode("utf-8")
+    resp = http.request("POST", url, body=encoded_msg)
+    print({"message": final_message, "status_code": resp.status, "response": resp.data})


### PR DESCRIPTION
Migrated `lambda_functions/tre-slack-alerts` from repo da-transform-judgments-pipeline. Added GitHub Action workflow to build and deploy Docker image to ECR. Uses AWS CodeArtifact as upstream `pip` source if requirements.txt contains package definitions.